### PR TITLE
Fix upstream proxy auth fail

### DIFF
--- a/spec/pacproxy_spec.rb
+++ b/spec/pacproxy_spec.rb
@@ -126,5 +126,25 @@ describe Pacproxy do
       res = c.get('http://127.0.0.1:13080/noproxy/')
       expect(res.status).to eq(200)
     end
+
+    it 'transfer request with auth to server via parent proxy' do
+      @pacproxy_server =
+        Pacproxy::Pacproxy.new(Port: 13_128,
+                               Proxypac: 'spec/all_proxy.pac')
+
+      Thread.new { @pacproxy_server.start }
+      wait_server_status(@pacproxy_server, :Running)
+
+      c = HTTPClient.new('http://127.0.0.1:13128')
+      header = { header: { 'proxy-authorization' =>
+          %Q(Basic #{['user01:pass01'].pack('m').delete("\n")})
+        }
+      }
+      p header: header
+      res = c.get('http://127.0.0.1:13080/', header)
+      expect(res.status).to eq(200)
+      res = c.get('http://127.0.0.1:13080/noproxy/', header)
+      expect(res.status).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
- Fix upstream proxy authentication fails when an upstream proxy requires an authentication.
  - users can specify own authentication ids or passwords
