### PR TITLE
Fix to work when upstream proxy require authentication

### DIFF
--- a/lib/pacproxy/pacproxy.rb
+++ b/lib/pacproxy/pacproxy.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 module Pacproxy
   # Pacproxy::Pacproxy represent http/https proxy server
-  class Pacproxy < WEBrick::HTTPProxyServer
+  class Pacproxy < WEBrick::HTTPProxyServer # rubocop:disable ClassLength
     include Loggable
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
@@ -39,6 +39,94 @@ module Pacproxy
       URI.parse("http://#{basic_auth.unpack('m').first}@#{proxy}")
     end
 
+    # This method is mainly from WEBrick::HTTPProxyServer.
+    # To allow upstream proxy authentication,
+    # it operate 407 response from an upstream proxy.
+    # see: https://github.com/ruby/ruby/blob/trunk/lib/webrick/httpproxy.rb
+    # rubocop:disable all
+    def do_CONNECT(req, res)
+      # Proxy Authentication
+      proxy_auth(req, res)
+
+      ua = Thread.current[:WEBrickSocket]  # User-Agent
+      raise WEBrick::HTTPStatus::InternalServerError,
+        "[BUG] cannot get socket" unless ua
+
+      host, port = req.unparsed_uri.split(":", 2)
+      # Proxy authentication for upstream proxy server
+      if proxy = proxy_uri(req, res)
+        proxy_request_line = "CONNECT #{host}:#{port} HTTP/1.0"
+        if proxy.userinfo
+          credentials = "Basic " + [proxy.userinfo].pack("m").delete("\n")
+        end
+        host, port = proxy.host, proxy.port
+      end
+
+      begin
+        @logger.debug("CONNECT: upstream proxy is `#{host}:#{port}'.")
+        os = TCPSocket.new(host, port)     # origin server
+
+        if proxy
+          @logger.debug("CONNECT: sending a Request-Line")
+          os << proxy_request_line << WEBrick::CRLF
+          @logger.debug("CONNECT: > #{proxy_request_line}")
+          if credentials
+            @logger.debug("CONNECT: sending a credentials")
+            os << "Proxy-Authorization: " << credentials << WEBrick::CRLF
+          end
+          os << WEBrick::CRLF
+          proxy_status_line = os.gets(WEBrick::LF)
+          @logger.debug("CONNECT: read a Status-Line form the upstream server")
+          @logger.debug("CONNECT: < #{proxy_status_line}")
+          if /^HTTP\/\d+\.\d+\s+(?<st>200|407)\s*/ =~ proxy_status_line
+            res.status = st.to_i
+            while line = os.gets(WEBrick::LF)
+              res.header['Proxy-Authenticate'] =
+                line.split(':')[1] if /Proxy-Authenticate/i =~ line
+              break if /\A(#{WEBrick::CRLF}|#{WEBrick::LF})\z/om =~ line
+            end
+          else
+            raise WEBrick::HTTPStatus::BadGateway
+          end
+        end
+        @logger.debug("CONNECT #{host}:#{port}: succeeded")
+      rescue => ex
+        @logger.debug("CONNECT #{host}:#{port}: failed `#{ex.message}'")
+        res.set_error(ex)
+        raise WEBrick::HTTPStatus::EOFError
+      ensure
+        if handler = @config[:ProxyContentHandler]
+          handler.call(req, res)
+        end
+        res.send_response(ua)
+        access_log(@config, req, res)
+
+        # Should clear request-line not to send the response twice.
+        # see: HTTPServer#run
+        req.parse(WEBrick::NullReader) rescue nil
+      end
+
+      begin
+        while fds = IO::select([ua, os])
+          if fds[0].member?(ua)
+            buf = ua.sysread(1024);
+            @logger.debug("CONNECT: #{buf.bytesize} byte from User-Agent")
+            os.syswrite(buf)
+          elsif fds[0].member?(os)
+            buf = os.sysread(1024);
+            @logger.debug("CONNECT: #{buf.bytesize} byte from #{host}:#{port}")
+            ua.syswrite(buf)
+          end
+        end
+      rescue
+        os.close
+        @logger.debug("CONNECT #{host}:#{port}: closed")
+      end
+
+      raise HTTPStatus::EOFError
+    end
+    # rubocop:enable all
+
     def proxy_auth(req, res)
       @config[:ProxyAuthProc].call(req, res) if @config[:ProxyAuthProc]
     end
@@ -60,6 +148,25 @@ module Pacproxy
       when /PROXY/
         primary_proxy = proxy_line.split(';')[0]
         /PROXY (.*)/.match(primary_proxy)[1]
+      end
+    end
+
+    # This method is mainly from WEBrick::HTTPProxyServer.
+    # proxy-authenticate can be transferred from a upstream proxy server
+    # to a client
+    # see: https://github.com/ruby/ruby/blob/trunk/lib/webrick/httpproxy.rb
+    HOP_BY_HOP = %w( connection keep-alive upgrade
+                     proxy-authorization te trailers transfer-encoding )
+    SHOULD_NOT_TRANSFER = %w( set-cookie proxy-connection )
+    def choose_header(src, dst)
+      connections = split_field(src['connection'])
+      src.each do |key, value|
+        key = key.downcase
+        next if HOP_BY_HOP.member?(key)        || # RFC2616: 13.5.1
+          connections.member?(key)             || # RFC2616: 14.10
+          SHOULD_NOT_TRANSFER.member?(key)        # pragmatics
+
+        dst[key] = value
       end
     end
 

--- a/spec/pacproxy_spec.rb
+++ b/spec/pacproxy_spec.rb
@@ -146,11 +146,60 @@ describe Pacproxy do
           %Q(Basic #{['user01:pass01'].pack('m').delete("\n")})
         }
       }
-      p header: header
       res = c.get('http://127.0.0.1:13080/', header)
       expect(res.status).to eq(200)
       res = c.get('http://127.0.0.1:13080/noproxy/', header)
       expect(res.status).to eq(200)
+    end
+
+    it 'respond 407 when upstrem proxy respond 407 on http' do
+      proxy_proc = proc do |_req, resp|
+        resp.header.merge!('Proxy-Authenticate' => "Basic realm=\"proxy\"")
+        fail WEBrick::HTTPStatus::ProxyAuthenticationRequired
+      end
+
+      pc = @proxy_server.instance_variable_get('@config')
+      @proxy_server.instance_variable_set('@config',
+                                          pc.merge(ProxyAuthProc: proxy_proc))
+      c = Pacproxy::Config.instance.config
+      c['port'] = 13_128
+      c['pac_file']['location'] = 'spec/all_proxy.pac'
+      @pacproxy_server = Pacproxy::Pacproxy.new(c)
+
+      Thread.new { @pacproxy_server.start }
+      wait_server_status(@pacproxy_server, :Running)
+
+      c = HTTPClient.new('http://127.0.0.1:13128')
+      res = c.get('http://127.0.0.1:13080/')
+      expect(res.status).to eq(407)
+      expect(res.header['Proxy-Authenticate']).to eq(["Basic realm=\"proxy\""])
+    end
+
+    it 'respond 407 when upstrem proxy respond 407 on https' do
+      proxy_proc = proc do |_req, resp|
+        resp.header.merge!('Proxy-Authenticate' => "Basic realm=\"proxy\"")
+        fail WEBrick::HTTPStatus::ProxyAuthenticationRequired
+      end
+
+      pc = @proxy_server.instance_variable_get('@config')
+      @proxy_server.instance_variable_set('@config',
+                                          pc.merge(ProxyAuthProc: proxy_proc))
+      c = Pacproxy::Config.instance.config
+      c['port'] = 13_128
+      c['pac_file']['location'] = 'spec/all_proxy.pac'
+      @pacproxy_server = Pacproxy::Pacproxy.new(c)
+
+      Thread.new { @pacproxy_server.start }
+      wait_server_status(@pacproxy_server, :Running)
+
+      c = HTTPClient.new('http://127.0.0.1:13128')
+      begin
+        c.get('https://127.0.0.1:13080/')
+      rescue => e
+        expect(e.res.status).to eq(407)
+        expect(e.res.header['Proxy-Authenticate'])
+          .to eq(["Basic realm=\"proxy\""])
+      end
     end
   end
 end


### PR DESCRIPTION
Browsers can not use pacproxy when upstream proxies require authentication,
but curl or wget can work with those upstream proxies.

Fix to process 407 response correctly from upstream proxies.
